### PR TITLE
Restore compatibility with Brahma v1 payloads

### DIFF
--- a/source/arm11.s
+++ b/source/arm11.s
@@ -76,6 +76,12 @@ wait_arm9_loop:
 	ANDS            R0, R0, #1
 	BNE	            wait_arm9_loop
 
+	@ get arm9 orig entry point phys addr from FIRM header
+	LDR             R0, [R10, #0x0C]
+
+	@ backup orig entry point to FCRAM + offs ARM9 payload + 4
+	STR             R0, [R9, #0x4]
+
 	@ overwrite orig entry point with FCRAM addr
 	@ this exploits the race condition bug
 	STR             R9, [R10, #0x0C]
@@ -136,7 +142,7 @@ loc_1020D0:
 	MOV             R0, #4
 delay:
 	MOV             R1, #0
-        MCR             p15, 0, r1, c7, c10, 0
+	MCR             p15, 0, r1, c7, c10, 0
 	MCR             p15, 0, r1, c7, c10, 4
 loop:
 	SUBS            R0, #1

--- a/source/brahma.c
+++ b/source/brahma.c
@@ -88,7 +88,6 @@ s32 setup_exploit_data (void) {
 s32 recv_arm9_payload (void) {
 	s32 sockfd;
 	struct sockaddr_in sa;
-	s32 ret;
 	u32 kDown, old_kDown;
 	s32 clientfd;
 	struct sockaddr_in client_addr;


### PR DESCRIPTION
Following up yesterdays discussion, I reverted the change in arm11.s, so that again the ARM9 entry point is stored as intended. Reverting this doesn't have any averse effects on boot success rates (tested with Decrypt9 & ReiNAND CFW). Also, @patois sample code reboots as intended again.
